### PR TITLE
Fix automatic positioning for non-16/9 resolutions

### DIFF
--- a/src/main.as
+++ b/src/main.as
@@ -74,7 +74,7 @@ void Update(float dt) {
     	// Calculate the equivalent position for all resolutions; X = 0.028 on 16/9 display. >16/9 -> offset, <16/9 -> squish
         float IdealWidth = Math::Min(ScreenWidth, ScreenHeight * 16.0 / 9.0);
         float AspectDiff = Math::Max(0.0, ScreenWidth / ScreenHeight - 16.0 / 9.0) / 2.0;
-        ButtonPosX = (0.028 * IdealWidth + ScreenHeight * AspectDiff) / ScreenWidth;
+        ButtonPosX = (0.028125 * IdealWidth + ScreenHeight * AspectDiff) / ScreenWidth;
         ButtonPosY = 0.333;
     }
 

--- a/src/main.as
+++ b/src/main.as
@@ -71,7 +71,10 @@ void Update(float dt) {
     if(AutoPlaceButton) {
         ButtonSizeX = ScreenHeight / 22.5;
         ButtonSizeY = ScreenHeight / 22.5;
-        ButtonPosX = 0.028;
+    	// Calculate the equivalent position for all resolutions; X = 0.028 on 16/9 display. >16/9 -> offset, <16/9 -> squish
+        float IdealWidth = Math::Min(ScreenWidth, ScreenHeight * 16.0 / 9.0);
+        float AspectDiff = Math::Max(0.0, ScreenWidth / ScreenHeight - 16.0 / 9.0) / 2.0;
+        ButtonPosX = (0.028 * IdealWidth + ScreenHeight * AspectDiff) / ScreenWidth;
         ButtonPosY = 0.333;
     }
 


### PR DESCRIPTION
Should work for all resolutions. I tested by dragging the TM window to other aspects in windowed mode.

example calc for 3440x1440 (found 0.1487 to be pixel perfect by trial and error)
```
idealWidth = 1440 * 16/9 = 2560
aspectDiff = (2.388888 - 1.7777777) / 2 = 0.3055555
btnPosX = (0.028 * 2560 + 1440 * 0.305555555) / 3440
        = (71.68 + 439.999) / 3440 = 0.14874...
```