### PR TITLE
Implement UltrawideUIFix support

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -5,3 +5,6 @@ category = "Utilities"
 version = "1.2.7"
 siteid = 229
 
+[script]
+optional_dependencies = ["UltrawideUIFix"]
+

--- a/src/Main.as
+++ b/src/Main.as
@@ -55,7 +55,14 @@ void Update(float dt) {
     	// Calculate the equivalent position for all resolutions; X = 0.028 on 16/9 display. >16/9 -> offset, <16/9 -> squish
         float IdealWidth = Math::Min(ScreenWidth, ScreenHeight * 16.0 / 9.0);
         float AspectDiff = Math::Max(0.0, ScreenWidth / ScreenHeight - 16.0 / 9.0) / 2.0;
+
+#if DEPENDENCY_ULTRAWIDEUIFIX
+        // We have a shift value from UltrawideUIFix, convert it to a fraction of a 16/9 display width and subtract it from the default position
+        ButtonPosX = ((0.028125 - (UltrawideUIFix::GetUiShift() / 320)) * IdealWidth + ScreenHeight * AspectDiff) / ScreenWidth;
+#else
         ButtonPosX = (0.028125 * IdealWidth + ScreenHeight * AspectDiff) / ScreenWidth;
+#endif
+
         ButtonPosY = 0.333;
     }
 


### PR DESCRIPTION
As I move the Records window in my [Ultrawide UI Fix plugin](https://openplanet.dev/plugin/ultrawideuifix), this results in the refresh button not being aligned with it. I've added an ability for other plugins to use the shift value in 4.1.0 and implemented it in this PR. Let me know if you have any questions and thank you for maintaining this plugin.