### PR TITLE
option to hide button when OP overlay is hidden

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -23,6 +23,7 @@ void Main() {
 }
 
 void Render() {
+    if(InterfaceToggle && !UI::IsOverlayShown()) return;
     if(!PermissionViewRecords || !UI::IsGameUIVisible()) return;
 	CTrackMania@ app = cast<CTrackMania>(GetApp());
     if(app is null) return;
@@ -80,7 +81,7 @@ void Update(float dt) {
 
     // Declare PermissionViewRecords variable, for reuse in the logic, without the cost of calling Permissions::ViewRecords()
     PermissionViewRecords = Permissions::ViewRecords();
-    
+
     // Declare CurrentlyInMap variable
     CTrackMania@ app = cast<CTrackMania>(GetApp());
 

--- a/src/Settings/Button.as
+++ b/src/Settings/Button.as
@@ -1,6 +1,9 @@
 [Setting hidden category="Button" name="Automatic placement of button"]
 bool AutoPlaceButton = true;
 
+[Setting hidden category="Button" name="Hide when Openplanet overlay is hidden"]
+bool InterfaceToggle = false;
+
 [Setting hidden category="Button" name="Button Size X"]
 float ButtonSizeX = 48;
 [Setting hidden category="Button" name="Button Size Y"]
@@ -21,6 +24,7 @@ void RenderSettingsButton()
 	UI::TextWrapped("Disable Automatic placement of button to customize button size and position.");
 
 	AutoPlaceButton = UI::Checkbox("Automatic placement of button", AutoPlaceButton);
+	InterfaceToggle = UI::Checkbox("Hide when Openplanet overlay is hidden", InterfaceToggle);
 
     if(!AutoPlaceButton) {
         UI::Dummy(vec2(0,5));


### PR DESCRIPTION
Added the option to hide the Refresh Leaderboard Button, when the OpenPlanet Overlay is hidden.