### PR TITLE
fixed not showing on servers, fixed nullptr on UISequence

### DIFF
--- a/src/Leaderboard.as
+++ b/src/Leaderboard.as
@@ -27,7 +27,10 @@ namespace Leaderboard {
         CTrackMania@ App = cast<CTrackMania@>(GetApp());
 
         CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode@>(App.PlaygroundScript);
-        if (PlaygroundScript is null || PlaygroundScript.StartTime > 2147483000)
+        if (PlaygroundScript is null)  // null when on servers, can't check StartTime in this case
+            return true;
+
+        if (PlaygroundScript.StartTime > 2147483000)
             return false;
 
         return true;
@@ -63,12 +66,13 @@ namespace Leaderboard {
         CTrackMania@ app = cast<CTrackMania>(GetApp());
         if(app is null) return false;
         CGameCtnNetwork@ Network = app.Network;
-        if(Network is null) return false;
+        if(
+            Network is null
+            || Network.ClientManiaAppPlayground is null
+            || Network.ClientManiaAppPlayground.UI is null
+        ) return false;
 
         CGamePlaygroundUIConfig::EUISequence uiSeq = Network.ClientManiaAppPlayground.UI.UISequence;
-
-        if (uiSeq == CGamePlaygroundUIConfig::EUISequence::EndRound)
-            return false;
 
         return uiSeq == CGamePlaygroundUIConfig::EUISequence::Playing
             || uiSeq == CGamePlaygroundUIConfig::EUISequence::Finish;


### PR DESCRIPTION
Hey, I'm so sorry but I messed up in the last PR and forgot to test on a server. It ended up not showing at all since `App.PlaygroundScript` is null on servers, but this should be fixed now. I should've taken more time to test it. Also just made a possible `nullptr` access safer.