### PR TITLE
option to hide button when OP overlay is hidden

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -23,6 +23,7 @@ void Main() {
 }
 
 void Render() {
+    if(InterfaceToggle && !UI::IsOverlayShown()) return;
     if(!PermissionViewRecords || !UI::IsGameUIVisible()) return;
 	CTrackMania@ app = cast<CTrackMania>(GetApp());
     if(app is null) return;

--- a/src/Settings/Button.as
+++ b/src/Settings/Button.as
@@ -1,6 +1,9 @@
 [Setting hidden category="Button" name="Automatic placement of button"]
 bool AutoPlaceButton = true;
 
+[Setting hidden category="Button" name="Hide when Openplanet overlay is hidden"]
+bool InterfaceToggle = false;
+
 [Setting hidden category="Button" name="Button Size X"]
 float ButtonSizeX = 48;
 [Setting hidden category="Button" name="Button Size Y"]
@@ -21,6 +24,7 @@ void RenderSettingsButton()
 	UI::TextWrapped("Disable Automatic placement of button to customize button size and position.");
 
 	AutoPlaceButton = UI::Checkbox("Automatic placement of button", AutoPlaceButton);
+	InterfaceToggle = UI::Checkbox("Hide when Openplanet overlay is hidden", InterfaceToggle);
 
     if(!AutoPlaceButton) {
         UI::Dummy(vec2(0,5));


### PR DESCRIPTION
I have used this altered version of your plugin for quite a long time, but didn't think other people would be interested in my feature. However because of school mode I would appreciate, if it could be added to main version, so I can use it online.

I basicly use the OP Overlay with the HUD Picker Plugin to toggle my entire interface on/off. This allows me to replicate HUD off while still seeing my splits. However despite the entire Leaderboard being hidden, the refresh button remains visible - hence this small addition.

I would appreciate it if you could approve this, even though it may only be useful to myself :)